### PR TITLE
Add email field to event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-amplitude",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-amplitude",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Storybook Addon for Amplitude",
   "scripts": {
     "clean": "rimraf dist",

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ module.exports = {
 };
 ```
 
-Then, set an environment variable with your API key:
+Then, set on `window` object a key `STORYBOOK_AMPLITUDE_API_KEY` using your API key as value:
 
 ```
 window.STORYBOOK_AMPLITUDE_API_KEY = 'YOUR_API_KEY_HERE'
@@ -26,13 +26,14 @@ window.STORYBOOK_AMPLITUDE_API_KEY = 'YOUR_API_KEY_HERE'
 
 ### Configuration
 
-You can use a custom event name setting an environment variable:
+You can use a custom event name and identify each event with an email by setting the following values on `window` object:
 
 ```
 window.STORYBOOK_AMPLITUDE_EVENT = 'Your custom event'
+window.USER_EMAIL = 'email'
 ```
 
-The default value is `Story Viewed`.
+The default value for `STORYBOOK_AMPLITUDE_EVENT` is `Story Viewed`.
 
 ## Event anatomy
 

--- a/src/amplitude.js
+++ b/src/amplitude.js
@@ -15,6 +15,7 @@ export class Amplitude {
 
     if (shouldLog(path)) {
       this.amplitudeInstance.logEvent(getEventType(), {
+        email: window.USER_EMAIL,
         viewMode,
         ...getEventPropsByPath(path)
       });


### PR DESCRIPTION
This PR adds a field `email` to the event. To use it, just set a `window` key `USER_EMAIL` on your storybook.